### PR TITLE
Exclude tests directory from being packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cloudconvert/cloudconvert-python",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
         "requests",
         "urllib3"


### PR DESCRIPTION
The tests directory was being packaged and installed with the library.

You can verify it by installing directly using `pip install cloudconvert`. It'll install the 'tests' directory in site-packages.

This PR fixes that.